### PR TITLE
Updated documentation to allow personal folder browsing and analytics file deletion

### DIFF
--- a/user-guide/3.-Portals-Roambi-File-System-(RFS).md
+++ b/user-guide/3.-Portals-Roambi-File-System-(RFS).md
@@ -96,13 +96,9 @@ Retrieves all contents for the specified folder, Portal, and organization.
 
 ### Method:
 
-
-```
-
-**GET** /accounts/`$ACCOUNT_UID`/portals/`$PORTAL_UID`/contents
+`GET /accounts/$ACCOUNT_UID/portals/$PORTAL_UID/contents`
 
 
-```
 ### Parameters:
 
 | Parameter | Required? | Data type | Description |
@@ -122,20 +118,48 @@ Available meta-types are:
 
 ### Returns:
 
-Returns a file/folder directory tree for a specific Portal.
+Returns a list of files / folders in a specific Portal.  If a specific parent folder
+is specified, then the contents of that folder are returned.  If no parent folder is
+specified, then the root contents of the portal returned.
+
+This can be used to get the contents of either a Personal Folder or an account-wide folder.
+
+### Access Control
+
+**Permitted roles:**  viewer, publisher, administrator
+
+The following rules apply with respect to content security when using this API resource:
+*  When listing the contents of a portal or folder, only items accessible by the current user are returned
+*  When listing the contents of a Personal Folder
+  1.  If the current user is an account administrator, all items in the folder are visible
+  *   If the current user is the owner of the Personal Folder, all items in the folder are visible
+  *  Otherwise, no items are visible (the endpoint will return an empty set of items)
+
+
 
 ### Error responses:
 
 See <a href="https://support.roambi.com/entries/23851988-API-error-codes">API error codes</a>.
 
-### Example request:
 
-
+### Example requests:
 ```
-# curl https://api.roambi.com/1/accounts/`$ACCOUNT_UID`/portals/`$PORTAL_UID`/contents \
-  -H "Authorization: Bearer `$ACCESS_TOKEN`" \
+# Gets the root contents of the portal
+
+$> curl https://api.roambi.com/1/accounts/$ACCOUNT_UID/portals/$PORTAL_UID/contents \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
 -X GET
 ```
+
+```
+# Gets the contents of a sub-directory in a portal
+
+$> curl https://api.roambi.com/1/accounts/$ACCOUNT_UID/portals/$PORTAL_UID/contents?folder_uid=d7d13bc3-d941-4ab6-b209-9b891a26b977 \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+-X GET
+```
+
+
 ### Example response:
 
 
@@ -150,7 +174,7 @@ See <a href="https://support.roambi.com/entries/23851988-API-error-codes">API er
     "updated_at": "2012-04-18"
   },
   {
-    "uid": "5175b9ed84aeb...",
+    "uid": "544f305f7b28fdad4c9a4e61",
     "title": "Source Files",
     "read_only": "false",
     "file_type": "FOLDER",
@@ -158,7 +182,7 @@ See <a href="https://support.roambi.com/entries/23851988-API-error-codes">API er
     "updated_at": "2012-04-22"
   },
   {
-    "uid": "695ff138-fa21-42...",
+    "uid": "133aec20-c2c4-444b-a847-d5e592ffe9ba",
     "title": "My Documents",
     "read_only": "false",
     "file_type": "FOLDER",

--- a/user-guide/5.3 Remove Files.md
+++ b/user-guide/5.3 Remove Files.md
@@ -1,14 +1,14 @@
-This method deletes a data source file in the Roambi Library.
-
- Note: The published RBI files may not be removed via this endpoint.
+This method deletes a file in the Roambi Library.  The target file can be an Analytics file (RBI) or a source file (csv, xls, etc.)
 
 ### Method:
 
-**DELETE** /accounts/`$ACCOUNT_UID`/files/`$FILE_UID`
+`DELETE /accounts/$ACCOUNT_UID/files/$FILE_UID`
+
 
 ### Parameters:
 
 None.
+
 
 ### Returns:
 
@@ -21,6 +21,7 @@ Returns deleted file uid as a confirmation.
 | Error Code | Description |
 |-----|-----|-----|
 | *access_denied* | User does not have access to at least one resource related to this request. This may include trying to write to a read-only destination. |
+
 
 ### Example request:
 


### PR DESCRIPTION
FOR REVIEW ONLY

I have updated the descriptions for two endpoints (portal content browsing and file deletion) to handle the need to delete RBI files in a user's Personal Folder.  To accomplish this, I am proposing the following changes to current behavior:
-  the file deletion endpoint (`DELETE /accounts/${account_uid}/files/${file_uid}`) will allow deletion of analytics files (RBIs)
-  the portal contents endpoint (`GET /accounts/${account_uid}/portals/${portal_uid}/contents`) will allow browsing of Personal Folders (subject to specified security restrictions)

Please update this PR with comments / suggestions.  The goal is to drive the acceptance criteria for sprint tasks based on the changes in the documentation.
